### PR TITLE
Exclude doxygen prod files

### DIFF
--- a/projects/FHC-AtmelStudio/.gitignore
+++ b/projects/FHC-AtmelStudio/.gitignore
@@ -13,6 +13,9 @@
 [Dd]ebug/
 [Rr]elease/
 
+#Doxygen Build
+doxygen/
+
 #Build Results
 *.o
 *.d


### PR DESCRIPTION
In some feature branch, doxygen is introduced as new tool.

This is to prevent doxygen productive artifacts from being committed.

It was tested locally that it works.